### PR TITLE
Implement lower bound computations

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,5 +12,5 @@ Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
 
 [compat]
-JuMP = "~0.21"
+JuMP = "~0.21.7"
 julia = ">= 1.0"

--- a/src/ProgressiveHedging.jl
+++ b/src/ProgressiveHedging.jl
@@ -35,7 +35,8 @@ export convert_to_variable_ids, convert_to_xhat_id
 export is_leaf, name, value, branch_value, leaf_value, w_value, xhat_value
 
 # Result retrieval functions
-export residuals, relative_residuals, residual_components
+export lower_bounds
+export residuals
 export retrieve_soln, retrieve_obj_value, retrieve_no_hats, retrieve_w
 export retrieve_xhat_history, retrieve_no_hat_history, retrieve_w_history
 
@@ -122,6 +123,7 @@ function solve(tree::ScenarioTree,
                report::Int=0,
                save_iterates::Int=0,
                save_residuals::Int=0,
+               lower_bound::Int=0,
                timing::Bool=true,
                warm_start::Bool=false,
                callbacks::Vector{Callback}=Vector{Callback}(),
@@ -157,6 +159,7 @@ function solve(tree::ScenarioTree,
                                      warm_start,
                                      timo,
                                      report,
+                                     lower_bound,
                                      (other_args...,args...);
                                      kwargs...)
                           )
@@ -169,7 +172,8 @@ function solve(tree::ScenarioTree,
     if report > 0
         println("Solving...")
     end
-    (niter, abs_res, rel_res) = @timeit(timo, "Solution",
+    (niter, abs_res, rel_res) = @timeit(timo,
+                                        "Solution",
                                         hedge(phd,
                                               winf,
                                               max_iter,
@@ -177,7 +181,8 @@ function solve(tree::ScenarioTree,
                                               rtol,
                                               report,
                                               save_iterates,
-                                              save_residuals)
+                                              save_residuals,
+                                              lower_bound)
                                         )
 
     # Post Processing

--- a/src/ProgressiveHedging.jl
+++ b/src/ProgressiveHedging.jl
@@ -108,10 +108,11 @@ Solve the stochastic programming problem described by `tree` and the models crea
 * `report::Int` : Print progress to screen every `report` iterations. Any value <= 0 disables printing. Defaults to 0.
 * `save_iterates::Int` : Save PH iterates every `save_iterates` steps. Any value <= 0 disables saving iterates. Defaults to 0.
 * `save_residuals::Int` : Save PH residuals every `save_residuals` steps. Any value <= 0 disables saving residuals. Defaults to 0.
+* `lower_bound::Int` : Compute and save a lower-bound using (Gade, et. al. 2016) every `lower_bound` iterations. Any value <= disables lower-bound computation. Defaults to 0.
 * `timing::Bool` : Print timing info after solving if true. Defaults to true.
 * `warm_start::Bool` : Flag indicating that solver should be "warm started" by using the previous solution as the starting point (not compatible with all solvers)
 * `callbacks::Vector{Callback}` : Collection of `Callback` structs to call after each PH iteration. Callbacks will be executed in the order they appear. See `Callback` struct for more info. Defaults to empty vector.
-* `subproblem_callbacks::Vector{SubproblemCallback}` : Collection of `SubproblemCallback` structs to call after each PH iteration similarly to `callbacks`. These must not require communication between subproblems, and as such should be more efficient than regular callbacks. 
+* `subproblem_callbacks::Vector{SubproblemCallback}` : Collection of `SubproblemCallback` structs to call before solving each subproblem. Each callback is called on each subproblem but does not affect other subproblems. See `SubproblemCallback` struct for more info. Defaults to empty vector.
 * `worker_assignments::Dict{Int,Set{ScenarioID}}` : Dictionary specifying which scenario subproblems a worker will create and solve. The key values are worker ids as given by Distributed (see `Distributed.workers()`). The user is responsible for ensuring the specified workers exist and that every scenario is assigned to a worker. If no dictionary is given, scenarios are assigned to workers in round robin fashion. Defaults to empty dictionary.
 * `args::Tuple` : Tuple of arguments to pass to `model_cosntructor`. Defaults to (). See also `other_args` and `kwargs`.
 * `kwargs` : Any keyword arguments not specified here that need to be passed to `subproblem_constructor`.  See also `other_args` and `args`.

--- a/src/ProgressiveHedging.jl
+++ b/src/ProgressiveHedging.jl
@@ -109,7 +109,7 @@ Solve the stochastic programming problem described by `tree` and the models crea
 * `atol::Float64` : Absolute error tolerance. Defaults to 1e-6.
 * `rtol::Float64` : Relative error tolerance. Defaults to 1e-6.
 * `gap_tol::Float64` : Relative gap tolerance. Terminate when the relative gap between the lower bound and objective are smaller than `gap_tol`. Any value < 0.0 disables this termination condition. Defaults to -1.0. See also the `lower_bound` keyword argument.
-* `lower_bound::Int` : Compute and save a lower-bound using (Gade, et. al. 2016) every `lower_bound` iterations. Any value <= disables lower-bound computation. Defaults to 0.
+* `lower_bound::Int` : Compute and save a lower-bound using (Gade, et. al. 2016) every `lower_bound` iterations. Any value <= 0 disables lower-bound computation. Defaults to 0.
 * `report::Int` : Print progress to screen every `report` iterations. Any value <= 0 disables printing. Defaults to 0.
 * `save_iterates::Int` : Save PH iterates every `save_iterates` steps. Any value <= 0 disables saving iterates. Defaults to 0.
 * `save_residuals::Int` : Save PH residuals every `save_residuals` steps. Any value <= 0 disables saving residuals. Defaults to 0.

--- a/src/ProgressiveHedging.jl
+++ b/src/ProgressiveHedging.jl
@@ -82,10 +82,13 @@ include("callbacks.jl")
           max_iter::Int=1000,
           atol::Float64=1e-6,
           rtol::Float64=1e-6,
+          gap_tol::Float64=-1.0,
+          lower_bound::Int=0,
           report::Int=0,
           save_iterates::Int=0,
           save_residuals::Bool=false,
           timing::Bool=true,
+          warm_start::Bool=false,
           callbacks::Vector{Callback}=Vector{Callback}(),
           worker_assignments::Dict{Int,Set{ScenarioID}}=Dict{Int,Set{ScenarioID}}(),
           args::Tuple=(),
@@ -105,10 +108,11 @@ Solve the stochastic programming problem described by `tree` and the models crea
 * `max_iter::Int` : Maximum number of iterations to perform before returning. Defaults to 1000.
 * `atol::Float64` : Absolute error tolerance. Defaults to 1e-6.
 * `rtol::Float64` : Relative error tolerance. Defaults to 1e-6.
+* `gap_tol::Float64` : Relative gap tolerance. Terminate when the relative gap between the lower bound and objective are smaller than `gap_tol`. Any value < 0.0 disables this termination condition. Defaults to -1.0. See also the `lower_bound` keyword argument.
+* `lower_bound::Int` : Compute and save a lower-bound using (Gade, et. al. 2016) every `lower_bound` iterations. Any value <= disables lower-bound computation. Defaults to 0.
 * `report::Int` : Print progress to screen every `report` iterations. Any value <= 0 disables printing. Defaults to 0.
 * `save_iterates::Int` : Save PH iterates every `save_iterates` steps. Any value <= 0 disables saving iterates. Defaults to 0.
 * `save_residuals::Int` : Save PH residuals every `save_residuals` steps. Any value <= 0 disables saving residuals. Defaults to 0.
-* `lower_bound::Int` : Compute and save a lower-bound using (Gade, et. al. 2016) every `lower_bound` iterations. Any value <= disables lower-bound computation. Defaults to 0.
 * `timing::Bool` : Print timing info after solving if true. Defaults to true.
 * `warm_start::Bool` : Flag indicating that solver should be "warm started" by using the previous solution as the starting point (not compatible with all solvers)
 * `callbacks::Vector{Callback}` : Collection of `Callback` structs to call after each PH iteration. Callbacks will be executed in the order they appear. See `Callback` struct for more info. Defaults to empty vector.
@@ -124,10 +128,11 @@ function solve(tree::ScenarioTree,
                max_iter::Int=1000,
                atol::Float64=1e-6,
                rtol::Float64=1e-6,
+               gap_tol::Float64=-1.0,
+               lower_bound::Int=0,
                report::Int=0,
                save_iterates::Int=0,
                save_residuals::Int=0,
-               lower_bound::Int=0,
                timing::Bool=true,
                warm_start::Bool=false,
                callbacks::Vector{Callback}=Vector{Callback}(),
@@ -185,6 +190,7 @@ function solve(tree::ScenarioTree,
                                               max_iter,
                                               atol,
                                               rtol,
+                                              gap_tol,
                                               report,
                                               save_iterates,
                                               save_residuals,
@@ -273,7 +279,6 @@ end # module
 
 #### TODOs ####
 
-# 1. Add tests for unimplemented subproblem error throwing?
-# 2. Add flag to solve call to turn off parallelism
-# 3. Add handling of nonlinear objective functions
-# 4. Add tests for nonlinear constraints (these should work currently but testing is needed)
+# 1. Add flag to solve call to turn off parallelism
+# 2. Add handling of nonlinear objective functions
+# 3. Add tests for nonlinear constraints (these should work currently but testing is needed)

--- a/src/ProgressiveHedging.jl
+++ b/src/ProgressiveHedging.jl
@@ -13,11 +13,10 @@ using TimerOutputs
 
 # High-level Functions
 export solve, solve_extensive
-export two_stage_tree
 
 # Callbacks
 export Callback
-export cb, mean_deviation, variable_reduction
+export cb, mean_deviation, variable_fixing
 export apply_to_subproblem
 
 # ID types and functions
@@ -31,7 +30,7 @@ export ProportionalPenaltyParameter, ScalarPenaltyParameter, SEPPenaltyParameter
 # PHData interaction function
 export consensus_variables, probability, scenarios
 
-# (Consensus) Variable interaction funcitons
+# (Consensus) Variable interaction functions
 export convert_to_variable_ids, convert_to_xhat_id
 export is_leaf, name, value, branch_value, leaf_value, w_value, xhat_value
 

--- a/src/algorithm.jl
+++ b/src/algorithm.jl
@@ -407,6 +407,7 @@ function hedge(ph_data::PHData,
                max_iter::Int,
                atol::Float64,
                rtol::Float64,
+               gap_tol::Float64,
                report::Int,
                save_iter::Int,
                save_res::Int,
@@ -461,6 +462,7 @@ function hedge(ph_data::PHData,
                && niter < max_iter
                && residual > atol
                && residual > rtol * xmax
+               && (lb_flag ? gap > lb * gap_tol : true)
                )
     
     while running
@@ -496,6 +498,7 @@ function hedge(ph_data::PHData,
                    && niter < max_iter
                    && residual > atol
                    && residual > rtol * xmax
+                   && (lb_flag ? gap > lb * gap_tol : true)
                    )
 
         if report_flag && (niter % report == 0 || !running)

--- a/src/algorithm.jl
+++ b/src/algorithm.jl
@@ -24,10 +24,8 @@ end
 
 function _process_reports(phd::PHData,
                           winf::WorkerInf,
-                          report_type::Union{Type{ReportBranch},
-                                             Type{ReportLeaf},
-                                             Type{ReportLowerBound}},
-                          )::Nothing
+                          report_type::Type{R}
+                          )::Nothing where R <: Report
 
     waiting_on = copy(scenarios(phd))
 

--- a/src/algorithm.jl
+++ b/src/algorithm.jl
@@ -64,7 +64,7 @@ end
 function _report_lower_bound(niter::Int, bound::Float64, gap::Float64)::Nothing
 
     @printf("Iter: %4d   Bound: %12.4e   Abs Gap: %12.4e   Rel Gap: %8.4g\n",
-            niter, bound, gap, abs(gap/bound)
+            niter, bound, gap, gap/bound
             )
     flush(stdout)
 
@@ -305,7 +305,7 @@ function compute_gap(phd::PHData)::NTuple{2,Float64}
         pd = sinfo.problem_data
         p = sinfo.prob
 
-        gap += p * (pd.obj - pd.lb_obj)
+        gap += p * abs(pd.obj - pd.lb_obj)
         lb += p * pd.lb_obj
 
     end
@@ -362,7 +362,7 @@ function update_gap(phd::PHData, winf::WorkerInf, niter::Int)::NTuple{2,Float64}
 
     _save_lower_bound(phd.history,
                       niter,
-                      PHLowerBound(lb, gap, abs(gap/lb))
+                      PHLowerBound(lb, gap, gap/lb)
                       )
 
     return (lb, gap)

--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -2,6 +2,11 @@
 
 #### Canned Callbacks ####
 
+"""
+    variable_fixing(; lag=2, eq_tol=1e-8)::Callback
+
+Implementation of the variable fixing convergence acceleration heuristic in section 2.2 of (Watson & Woodruff 2010).
+"""
 function variable_fixing(; lag=2, eq_tol=1e-8)::Callback
     ext = Dict{Symbol,Any}()
     ext[:lag] = lag
@@ -93,6 +98,13 @@ function _variable_fixing(external::Dict{Symbol,Any},
     return true
 end
 
+"""
+    mean_deviation(;tol::Float64=1e-8,
+                   save_deviations::Bool=false
+                   )::Callback
+
+Implementation of a termination criterion given in section 2.3 of (Watson & Woodruff 2010). There it is called 'td'.
+"""
 function mean_deviation(;tol::Float64=1e-8,
                         save_deviations::Bool=false
                         )::Callback

--- a/src/jumpsubproblem.jl
+++ b/src/jumpsubproblem.jl
@@ -135,6 +135,13 @@ function solve(js::JuMPSubproblem)::MOI.TerminationStatusCode
     return JuMP.termination_status(js.model)
 end
 
+function update_lagrange_terms(js::JuMPSubproblem,
+                               w_vals::Dict{VariableID,Float64}
+                               )::Nothing
+    update_ph_terms(js, w_vals, Dict{VariableID,Float64}())
+    return
+end
+
 function update_ph_terms(js::JuMPSubproblem,
                          w_vals::Dict{VariableID,Float64},
                          xhat_vals::Dict{VariableID,Float64}

--- a/src/jumpsubproblem.jl
+++ b/src/jumpsubproblem.jl
@@ -30,15 +30,6 @@ end
 
 ## JuMPSubproblem Penalty Parameter Functions ##
 
-# NOTE: temporary functions for coefficients of expressions
-# Future JuMP versions will implement this
-coefficient(a::JuMP.GenericAffExpr{C,V}, v::V) where {C,V} = get(a.terms, v, zero(C))
-coefficient(a::JuMP.GenericAffExpr{C,V}, v1::V, v2::V) where {C,V} = zero(C)
-function coefficient(q::JuMP.GenericQuadExpr{C,V}, v1::V, v2::V) where {C,V}
-    return get(q.terms, UnorderedPair(v1,v2), zero(C))
-end
-coefficient(q::JuMP.GenericQuadExpr{C,V}, v::V) where {C,V} = coefficient(q.aff, v)
-
 function get_penalty_value(r::Float64,
                            vid::VariableID,
                            )::Float64
@@ -51,12 +42,11 @@ function get_penalty_value(r::Dict{VariableID,Float64},
     return r[vid]
 end
 
-## Interface Functions ##
+## AbstractSubproblem Interface Functions ##
 
-function add_ph_objective_terms(js::JuMPSubproblem,
-                                vids::Vector{VariableID},
-                                r::Union{Float64,Dict{VariableID,Float64}},
-                                )::Nothing
+function add_lagrange_terms(js::JuMPSubproblem,
+                            vids::Vector{VariableID}
+                            )::Nothing
 
     obj = JuMP.objective_function(js.model,
                                   JuMP.GenericQuadExpr{Float64, JuMP.VariableRef}
@@ -70,19 +60,22 @@ function add_ph_objective_terms(js::JuMPSubproblem,
 
     for vid in vids
         var = js.vars[vid]
-
         w_ref = JuMP.add_variable(js.model, JuMP.build_variable(error, jvi))
         JuMP.add_to_expression!(obj, w_ref, var)
         js.w_vars[vid] = w_ref
-
-        xhat_ref = JuMP.add_variable(js.model, JuMP.build_variable(error, jvi))
-        rho = get_penalty_value(r, vid)
-        JuMP.add_to_expression!(obj, 0.5 * rho * (var - xhat_ref)^2)
-        js.xhat_vars[vid] = xhat_ref
     end
 
     JuMP.set_objective_function(js.model, obj)
 
+    return
+end
+
+function add_ph_objective_terms(js::JuMPSubproblem,
+                                vids::Vector{VariableID},
+                                r::Union{Float64,Dict{VariableID,Float64}},
+                                )::Nothing
+    add_lagrange_terms(js, vids)
+    add_proximal_terms(js, vids, r)
     return
 end
 
@@ -187,13 +180,41 @@ end
 
 ## JuMPSubproblem Specific Functions ##
 
+function add_proximal_terms(js::JuMPSubproblem,
+                            vids::Vector{VariableID},
+                            r::Union{Float64,Dict{VariableID,Float64}}
+                            )::Nothing
+
+    obj = JuMP.objective_function(js.model,
+                                  JuMP.GenericQuadExpr{Float64, JuMP.VariableRef}
+                                  )
+
+    jvi = JuMP.VariableInfo(false, NaN,   # lower_bound
+                            false, NaN,   # upper_bound
+                            true, 0.0,    # fixed
+                            false, NaN,   # start value
+                            false, false) # binary, integer
+
+    for vid in vids
+        var = js.vars[vid]
+        xhat_ref = JuMP.add_variable(js.model, JuMP.build_variable(error, jvi))
+        rho = get_penalty_value(r, vid)
+        JuMP.add_to_expression!(obj, 0.5 * rho * (var - xhat_ref)^2)
+        js.xhat_vars[vid] = xhat_ref
+    end
+
+    JuMP.set_objective_function(js.model, obj)
+
+    return
+end
+
 function objective_coefficients(js::JuMPSubproblem,
                                 vids::Vector{VariableID},
                                 )::Dict{VariableID,Float64}
     pen_dict = Dict{VariableID,Float64}()
     obj = JuMP.objective_function(js.model)
     for vid in vids
-        pen_dict[vid] = coefficient(obj, js.vars[vid])
+        pen_dict[vid] = JuMP.coefficient(obj, js.vars[vid])
     end
     return pen_dict
 end

--- a/src/jumpsubproblem.jl
+++ b/src/jumpsubproblem.jl
@@ -138,23 +138,25 @@ end
 function update_lagrange_terms(js::JuMPSubproblem,
                                w_vals::Dict{VariableID,Float64}
                                )::Nothing
-    update_ph_terms(js, w_vals, Dict{VariableID,Float64}())
+
+    for (wid, wval) in pairs(w_vals)
+        JuMP.fix(js.w_vars[wid], wval, force=true)
+    end
+
     return
+
 end
 
 function update_ph_terms(js::JuMPSubproblem,
                          w_vals::Dict{VariableID,Float64},
                          xhat_vals::Dict{VariableID,Float64}
                          )::Nothing
-    for (wid, wval) in pairs(w_vals)
-        JuMP.fix(js.w_vars[wid], wval, force=true)
-    end
 
-    for (xhid, xhval) in pairs(xhat_vals)
-        JuMP.fix(js.xhat_vars[xhid], xhval, force=true)
-    end
+    update_lagrange_terms(js, w_vals)
+    update_proximal_terms(js, xhat_vals)
 
     return
+
 end
 
 function warm_start(js::JuMPSubproblem)::Nothing
@@ -213,6 +215,19 @@ function add_proximal_terms(js::JuMPSubproblem,
     JuMP.set_objective_function(js.model, obj)
 
     return
+
+end
+
+function fix_variables(js::JuMPSubproblem,
+                       vids::Dict{VariableID,Float64}
+                       )::Nothing
+
+    for (vid, val) in pairs(vids)
+        JuMP.fix(js.vars[vid], val, force=true)
+    end
+
+    return
+
 end
 
 function objective_coefficients(js::JuMPSubproblem,
@@ -226,15 +241,16 @@ function objective_coefficients(js::JuMPSubproblem,
     return pen_dict
 end
 
-function fix_variables(js::JuMPSubproblem,
-                       vids::Dict{VariableID,Float64}
-                       )::Nothing
+function update_proximal_terms(js::JuMPSubproblem,
+                               xhat_vals::Dict{VariableID,Float64}
+                               )::Nothing
 
-    for (vid, val) in pairs(vids)
-        JuMP.fix(js.vars[vid], val, force=true)
+    for (xhid, xhval) in pairs(xhat_vals)
+        JuMP.fix(js.xhat_vars[xhid], xhval, force=true)
     end
 
     return
+
 end
 
 ## JuMPSubproblem Internal Functions ##

--- a/src/message.jl
+++ b/src/message.jl
@@ -13,6 +13,14 @@ struct Initialize{R <: AbstractPenaltyParameter} <: Message
     warm_start::Bool
 end
 
+struct InitializeLowerBound <: Message
+    create_subproblem::Function
+    create_subproblem_args::Tuple
+    create_subproblem_kwargs::NamedTuple
+    scenarios::Set{ScenarioID}
+    scenario_tree::ScenarioTree
+end
+
 struct PenaltyInfo <: Message
     scen::ScenarioID
     penalty::Union{Float64,Dict{VariableID,Float64}}
@@ -33,12 +41,24 @@ struct ReportLeaf <: Message
     vals::Dict{VariableID,Float64}
 end
 
+struct ReportLowerBound <: Message
+    scen::ScenarioID
+    sts::MOI.TerminationStatusCode
+    obj::Float64
+    time::Float64
+end
+
 struct ShutDown <: Message end
 
 struct Solve <: Message
     scen::ScenarioID
     w_vals::Dict{VariableID,Float64}
     xhat_vals::Dict{VariableID,Float64}
+end
+
+struct SolveLowerBound <: Message
+    scen::ScenarioID
+    w_vals::Dict{VariableID,Float64}
 end
 
 struct SubproblemAction <: Message

--- a/src/message.jl
+++ b/src/message.jl
@@ -1,6 +1,8 @@
 
 abstract type Message end
 
+abstract type Report <: Message end
+
 struct Abort <: Message end
 
 struct Initialize{R <: AbstractPenaltyParameter} <: Message
@@ -29,7 +31,7 @@ end
 
 struct Ping <: Message end
 
-struct ReportBranch <: Message
+struct ReportBranch <: Report
     scen::ScenarioID
     sts::MOI.TerminationStatusCode
     obj::Float64
@@ -37,12 +39,12 @@ struct ReportBranch <: Message
     vals::Dict{VariableID,Float64}
 end
 
-struct ReportLeaf <: Message
+struct ReportLeaf <: Report
     scen::ScenarioID
     vals::Dict{VariableID,Float64}
 end
 
-struct ReportLowerBound <: Message
+struct ReportLowerBound <: Report
     scen::ScenarioID
     sts::MOI.TerminationStatusCode
     obj::Float64

--- a/src/message.jl
+++ b/src/message.jl
@@ -19,6 +19,7 @@ struct InitializeLowerBound <: Message
     create_subproblem_kwargs::NamedTuple
     scenarios::Set{ScenarioID}
     scenario_tree::ScenarioTree
+    warm_start::Bool
 end
 
 struct PenaltyInfo <: Message

--- a/src/message.jl
+++ b/src/message.jl
@@ -5,6 +5,8 @@ abstract type Report <: Message end
 
 struct Abort <: Message end
 
+struct DumpState <: Message end
+
 struct Initialize{R <: AbstractPenaltyParameter} <: Message
     create_subproblem::Function
     create_subproblem_args::Tuple
@@ -76,4 +78,9 @@ end
 struct VariableMap <: Message
     scen::ScenarioID
     var_info::Dict{VariableID,VariableInfo} # VariableInfo definition in subproblem.jl
+end
+
+struct WorkerState{T} <: Message
+    id::Int
+    state::T
 end

--- a/src/setup.jl
+++ b/src/setup.jl
@@ -195,7 +195,7 @@ function initialize(scen_tree::ScenarioTree,
     end
     worker_inf = @timeit(timo,
                          "Launch Workers",
-                         _launch_workers(scen_per_worker, n_scenarios)
+                         _launch_workers(2*scen_per_worker, n_scenarios)
                          )
 
     # Initialize subproblems
@@ -259,14 +259,6 @@ function initialize(scen_tree::ScenarioTree,
                        _set_penalty_parameter(phd,
                                               worker_inf)
                        )
-
-    if lower_bound > 0
-        @timeit(timo,
-                "Initial Lower Bound",
-                _send_lb_solve_commands(phd,
-                                        worker_inf)
-                )
-    end
 
     # Save residual
     _save_residual(phd, -1, xhat_res_sq, x_res_sq, 0.0, 0.0)

--- a/src/structs.jl
+++ b/src/structs.jl
@@ -207,13 +207,13 @@ function Base.show(io::IO, cb::Callback)
 end
 
 """
-Struct for a consensus variable.
+Type representing a consensus variable.
 
-**Fields**
-
-*`value::Float64` : Current value of the consensus variable
-*`vars::Set{VariableID}` : Individual scenario variables contributing to this consensus variable
-*`is_integer::Bool` : Flag indicating that this variable is an integer (or binary)
+The following functions are available to the user to interact with consensus variables
+* [`is_integer`](@ref)
+* [`set_value`](@ref)
+* [`value`](@ref)
+* [`variables`](@ref)
 """
 mutable struct HatVariable
     value::Float64 # Current value of variable
@@ -224,10 +224,40 @@ end
 ## Primary PH Data Structure ##
 
 """
-Data structure used to store information and results for a stochastic programming problem. See the following functions to interact with this object:
+Data structure used to store information and results for a stochastic programming problem.
+
+See the following functions may be used to interact with this object:
+* [`apply_to_subproblem`](@ref)
+* [`branch_value`](@ref)
 * [`consensus_variables`](@ref)
+* [`convert_to_variable_ids`](@ref)
+* [`convert_to_xhat_id`](@ref)
+* [`get_callback`](@ref)
+* [`get_callback_ext`](@ref)
+* [`is_leaf`](@ref)
+* [`name`](@ref)
 * [`probability`](@ref)
+* [`scenario_bundle`](@ref)
 * [`scenarios`](@ref)
+* [`stage_id`](@ref)
+* [`value`](@ref)
+* [`w_value`](@ref)
+* [`xhat_value`](@ref)
+
+The following post solution functions are also available:
+* [`leaf_value`](@ref)
+* [`retrieve_soln`](@ref)
+* [`retrieve_aug_obj_value`](@ref)
+* [`retrieve_obj_value`](@ref)
+* [`retrieve_no_hats`](@ref)
+* [`retrieve_w`](@ref)
+
+If the corresponding save options are enabled, the saved terms may be accessed with one of the following:
+* [`lower_bounds`](@ref)
+* [`residuals`](@ref)
+* [`retrieve_xhat_history`](@ref)
+* [`retrieve_no_hat_history`](@ref)
+* [`retrieve_w_history`](@ref)
 """
 struct PHData
     r::AbstractPenaltyParameter
@@ -331,10 +361,18 @@ end
 
 """
     cb(f::Function)
+    cb(f::Function, ext::Dict{Symbol,Any})
+    cb(f::Function, initialize::Function)
+    cb(f::Function, initialize::Function, ext::Dict{Symbol,Any})
+    cb(name::String, f::Function, ext::Dict{Symbol,Any})
 
-Shorthand for `Callback(f)`.
+Shorthand for [`Callback`](@ref) functions with the same signature.
 """
 cb(f::Function) = Callback(f)
+cb(f::Function, ext::Dict{Symbol,Any}) = Callback(f, ext)
+cb(f::Function, initialize::Function) = Callback(f, initialize)
+cb(f::Function, initialize::Function, ext::Dict{Symbol,Any}) = Callback(f, initialize, ext)
+cb(name::String, f::Function, ext::Dict{Symbol,Any}) = Callback(name, f, ext)
 
 """
     Callback(f::Function, ext::Dict{Symbol,Any})
@@ -379,12 +417,13 @@ function HatVariable(val::Float64,vid::VariableID, is_int::Bool)
     return HatVariable(val, Set{VariableID}([vid]), is_int)
 end
 
-function is_integer(a::HatVariable)::Bool
-    return a.is_integer
+function add_variable(a::HatVariable, vid::VariableID)
+    push!(a.vars, vid)
+    return
 end
 
-function value(a::HatVariable)::Float64
-    return a.value
+function is_integer(a::HatVariable)::Bool
+    return a.is_integer
 end
 
 function set_value(a::HatVariable, v::Float64)::Nothing
@@ -392,9 +431,8 @@ function set_value(a::HatVariable, v::Float64)::Nothing
     return
 end
 
-function add_variable(a::HatVariable, vid::VariableID)
-    push!(a.vars, vid)
-    return
+function value(a::HatVariable)::Float64
+    return a.value
 end
 
 function variables(a::HatVariable)::Set{VariableID}

--- a/src/structs.jl
+++ b/src/structs.jl
@@ -590,8 +590,11 @@ end
 
 """
     leaf_value(phd::PHData, vid::VariableID)::Float64
+    leaf_value(phd::PHData, scen::ScenarioID, stage::StageID, idx::Index)::Float64
 
-Returns the value of the variable associated with `vid`. Must be a leaf variable.
+Returns the value of the variable associated with `vid` or with scenario `scen`, stage `stage` and index `idx`. Must be a leaf variable.
+
+**WARNING:** For computational efficiency, leaf values are collected only at the end of a PH run. Therefore, using this function in a callback will result in an error.
 
 See also: [`branch_value`](@ref), [`value`](@ref)
 """
@@ -599,13 +602,6 @@ function leaf_value(phd::PHData, vid::VariableID)::Float64
     return phd.scenario_map[scenario(vid)].leaf_vars[vid]
 end
 
-"""
-    leaf_value(phd::PHData, scen::ScenarioID, stage::StageID, idx::Index)::Float64
-
-Returns the value of the variable associated with with scenario `scen`, stage `stage` and index `idx`. Must be a leaf variable.
-
-See also: [`branch_value`](@ref), [`value`](@ref)
-"""
 function leaf_value(phd::PHData, scen::ScenarioID, stage::StageID, idx::Index)::Float64
     return leaf_value(phd, VariableID(scen, stage, idx))
 end

--- a/src/structs.jl
+++ b/src/structs.jl
@@ -259,7 +259,7 @@ function PHData(r::AbstractPenaltyParameter,
 
                 vnode = node(tree, vid.scenario, vid.stage)
 
-                if vnode == nothing
+                if isnothing(vnode)
                     error("Unable to locate scenario tree node for variable '$(vinfo.name)' occuring in scenario $(vid.scenario) and stage $(vid.stage).")
                 end
 
@@ -521,7 +521,7 @@ function get_callback(phd::PHData, name::String)::Callback
         end
     end
 
-    if return_cb === nothing
+    if isnothing(return_cb)
         error("Unable to find callback $name.")
     end
 

--- a/src/structs.jl
+++ b/src/structs.jl
@@ -255,7 +255,6 @@ struct PHData
     callbacks::Vector{Callback}
     xhat::Dict{XhatID, HatVariable}
     variable_data::Dict{VariableID, VariableData}
-    indexer::Indexer
     iterate_history::PHIterateHistory
     residual_history::PHResidualHistory
     time_info::TimerOutputs.TimerOutput
@@ -326,7 +325,6 @@ function PHData(r::AbstractPenaltyParameter,
                   Vector{Callback}(),
                   xhat_dict,
                   var_data,
-                  idxr,
                   PHIterateHistory(),
                   PHResidualHistory(),
                   time_out,

--- a/src/structs.jl
+++ b/src/structs.jl
@@ -66,9 +66,13 @@ mutable struct ProblemData
     obj::Float64
     sts::MOI.TerminationStatusCode
     time::Float64
+    lb_obj::Float64
+    lb_sts::MOI.TerminationStatusCode
+    lb_time::Float64
 end
 
-ProblemData() = ProblemData(0.0, MOI.OPTIMIZE_NOT_CALLED, 0.0)
+ProblemData() = ProblemData(0.0, MOI.OPTIMIZE_NOT_CALLED, 0.0,
+                            0.0, MOI.OPTIMIZE_NOT_CALLED, 0.0)
 
 struct ScenarioInfo
     pid::Int
@@ -129,20 +133,10 @@ struct PHIterate
     w::Dict{VariableID,Float64}
 end
 
-struct PHIterateHistory
-    iterates::Dict{Int,PHIterate}
-end
-
-function PHIterateHistory()
-    return PHIterateHistory(Dict{Int,PHIterate}())
-end
-
-function _save_iterate(phih::PHIterateHistory,
-                       iter::Int,
-                       phi::PHIterate,
-                       )::Nothing
-    phih.iterates[iter] = phi
-    return
+struct PHLowerBound
+    lower_bound::Float64
+    gap::Float64
+    rel_gap::Float64
 end
 
 struct PHResidual
@@ -152,47 +146,37 @@ struct PHResidual
     x_sq::Float64
 end
 
-struct PHResidualHistory
-    residuals::Dict{Int,PHResidual}
+struct PHHistory
+    iterates::Dict{Int, PHIterate}
+    residuals::Dict{Int, PHResidual}
+    lower_bounds::Dict{Int, PHLowerBound}
 end
 
-function PHResidualHistory()::PHResidualHistory
-    return PHResidualHistory(Dict{Int,PHResidual}())
+function PHHistory()
+    return PHHistory(Dict{Int, PHIterate}(),
+                     Dict{Int, PHResidual}(),
+                     Dict{Int, PHLowerBound}(),
+                     )
 end
 
-function residual_vector(phrh::PHResidualHistory)::Vector{Float64}
-    if length(phrh.residuals) > 0
-        max_iter = maximum(keys(phrh.residuals))
-        return [phrh.residuals[k].abs_res for k in sort!(collect(keys(phrh.residuals)))]
-    else
-        return Vector{Float64}()
-    end
+function _save_iterate(phh::PHHistory,
+                       iter::Int,
+                       phi::PHIterate
+                       )::Nothing
+    phh.iterates[iter] = phi
+    return
 end
 
-function relative_residual_vector(phrh::PHResidualHistory)::Vector{Float64}
-    if length(phrh.residuals) > 0
-        max_iter = maximum(keys(phrh.residuals))
-        return [phrh.residuals[k].rel_res for k in sort!(collect(keys(phrh.residuals)))]
-    else
-        return Vector{Float64}()
-    end
+function _save_lower_bound(phh::PHHistory,
+                           iter::Int,
+                           phlb::PHLowerBound
+                           )::Nothing
+    phh.lower_bounds[iter] = phlb
+    return
 end
 
-function residual_components(phrh::PHResidualHistory)::NTuple{2,Vector{Float64}}
-    if length(phrh.residuals) > 0
-        max_iter = maximum(keys(phrh.residuals))
-        sorted_keys = sort!(collect(keys(phrh.residuals)))
-        xhat_sq = [phrh.residuals[k].xhat_sq for k in sorted_keys]
-        x_sq = [phrh.residuals[k].x_sq for k in sorted_keys]
-        return (xhat_sq, x_sq)
-    else
-        return (Vector{Float64}(), Vector{Float64}())
-    end
-end
-
-function _save_residual(phrh::PHResidualHistory, iter::Int, res::PHResidual)::Nothing
-    # @assert(!(iter in keys(phrh.residuals)))
-    phrh.residuals[iter] = res
+function _save_residual(phh::PHHistory, iter::Int, res::PHResidual)::Nothing
+    phh.residuals[iter] = res
     return
 end
 
@@ -255,8 +239,7 @@ struct PHData
     callbacks::Vector{Callback}
     xhat::Dict{XhatID, HatVariable}
     variable_data::Dict{VariableID, VariableData}
-    iterate_history::PHIterateHistory
-    residual_history::PHResidualHistory
+    history::PHHistory
     time_info::TimerOutputs.TimerOutput
 end
 
@@ -325,8 +308,7 @@ function PHData(r::AbstractPenaltyParameter,
                   Vector{Callback}(),
                   xhat_dict,
                   var_data,
-                  PHIterateHistory(),
-                  PHResidualHistory(),
+                  PHHistory(),
                   time_out,
                   )
 end
@@ -423,6 +405,7 @@ function variables(a::HatVariable)::Set{VariableID}
 end
 
 ## PHData Interaction Functions ##
+# NOTE: Additional, more complicated functions are in utils.jl
 
 """
     add_callback(phd::PHData,
@@ -564,33 +547,6 @@ Returns the probability of the given scenario.
 """
 function probability(phd::PHData, scenario::ScenarioID)::Float64
     return phd.scenario_map[scenario].prob
-end
-
-"""
-    residuals(phd::PHData)::Vector{Float64}
-
-Returns the absolute residuals at the iterations specified by the user.
-"""
-function residuals(phd::PHData)::Vector{Float64}
-    return residual_vector(phd.residual_history)
-end
-
-"""
-    residual_components(phd::PHData)::NTuple{2,Vector{Float64}}
-
-Returns the components of the absolute residual at the iterations specified by the user.
-"""
-function residual_components(phd::PHData)::NTuple{2,Vector{Float64}}
-    return residual_components(phd.residual_history)
-end
-
-"""
-    relative_residuals(phd::PHData)::Vector{Float64}
-
-Returns the relative residuals at the iterations specified by the user.
-"""
-function relative_residuals(phd::PHData)::Vector{Float64}
-    return relative_residual_vector(phd.residual_history)
 end
 
 """

--- a/src/subproblem.jl
+++ b/src/subproblem.jl
@@ -41,12 +41,12 @@ To use the extensive form functionality, the concrete subtype must implement
 See the help on the functions for more details. See JuMPSubproblem for an example using JuMP. Note that the extensive form model is always constructed as a `JuMP.Model` object.
 
 To use penalty parameter types other than `ScalarPenaltyParameter`, concrete subproblem types also need to implement
-* `report_penalty_info(sp::<ConcreateSubtype>, pp<:AbstractPenaltyParameter)::Dict{VariableID,Float64}`
+* `report_penalty_info(sp::<ConcreteSubtype>, pp<:AbstractPenaltyParameter)::Dict{VariableID,Float64}`
 See the help on individual penalty parameter types and `report_penalty_info` for more details.
 
 To use lower bound computation functionality, the concrete subtype must also implement
-* `add_lagrange_terms(as::AbstractSubproblem, vids::Vector{VariableID})::Nothing
-* `update_lagrange_terms(as::AbstractSubproblem, vids::Dict{VariableID,Float64})::Nothing
+* `add_lagrange_terms(sp::<ConcreteSubtype>, vids::Vector{VariableID})::Nothing
+* `update_lagrange_terms(sp::<ConcreteSubtype>, vids::Dict{VariableID,Float64})::Nothing
 See the help on these functions for more details.
 """
 abstract type AbstractSubproblem end

--- a/src/subproblem.jl
+++ b/src/subproblem.jl
@@ -23,7 +23,7 @@ A concrete subtype handles all details of creating, solving and updating subprob
 Variables and their values are identified and exchanged between PH and a Subproblem type using the `VariableID` type.  A unique `VariableID` is associated with each variable in the subproblem by the Subproblem implementation by using the `ScenarioID` of the subproblem as well as the `StageID` to which this variable belongs.  This combination uniquely identifies a node in the scenario tree to which the variable can be associated.  Variables associated with the same node in a scenario tree and sharing the same name are assumed to be consensus variables whose optimal value is determined by PH.  The final component of a `VariableID` is an `Index` which is just a counter assigned to a variable to differentiate it from other variables at the same node.  See `VariableID` type for more details.
 
 Any concrete subtype must implement the following functions:
-* `add_ph_objective_terms(sp::<ConcreteSubtype>, vids::Vector{VariableID}, r::AbstractPenaltyParameter)::Nothing
+* `add_ph_objective_terms(sp::<ConcreteSubtype>, vids::Vector{VariableID}, r::Union{Float64, Dict{VariableID,Float64}})::Nothing
 * `objective_value(sp::<ConcreteSubtype>)::Float64`
 * `report_values(sp::<ConcreteSubtype>, vars::Vector{VariableID})::Dict{VariableID,Float64}`
 * `report_variable_info(sp::<ConcreteSubtype>, st::ScenarioTree)::Dict{VariableID,VariableInfo}`

--- a/src/subproblem.jl
+++ b/src/subproblem.jl
@@ -54,7 +54,7 @@ abstract type AbstractSubproblem end
 """
     add_ph_objective_terms(as::AbstractSubproblem,
                            vids::Vector{VariableID},
-                           r::AbstractPenaltyParameter
+                           r::Union{Float64,Dict{VariableID,Float64}}
                            )::Dict{VariableID,Float64}
 
 Create model variables for Lagrange multipliers and hat variables and add lagrange and quadratic penalty terms to the objective function.
@@ -189,6 +189,24 @@ function warm_start(as::AbstractSubproblem)::Nothing
 end
 
 ## Optional Interface Functions ##
+
+"""
+TODO: Add documentation!!
+"""
+function add_lagrange_terms(as::AbstractSubproblem,
+                            vids::Vector{VariableID}
+                            )::Nothing
+    throw(UnimplementedError("add_lagrange_terms is unimplemented"))
+end
+
+"""
+TODO: Add documentation!!
+"""
+function update_lagrange_terms(as::AbstractSubproblem,
+                               vids::Dict{VariableID,Float64}
+                               )::Nothing
+    throw(UnimplementedError("update_lagrange_terms is unimplemented"))
+end
 
 # These functions are required only if an extensive form construction is desired
 

--- a/src/subproblem.jl
+++ b/src/subproblem.jl
@@ -22,7 +22,7 @@ A concrete subtype handles all details of creating, solving and updating subprob
 
 Variables and their values are identified and exchanged between PH and a Subproblem type using the `VariableID` type.  A unique `VariableID` is associated with each variable in the subproblem by the Subproblem implementation by using the `ScenarioID` of the subproblem as well as the `StageID` to which this variable belongs.  This combination uniquely identifies a node in the scenario tree to which the variable can be associated.  Variables associated with the same node in a scenario tree and sharing the same name are assumed to be consensus variables whose optimal value is determined by PH.  The final component of a `VariableID` is an `Index` which is just a counter assigned to a variable to differentiate it from other variables at the same node.  See `VariableID` type for more details.
 
-Any concrete subtype must implement the following functions:
+Any concrete subtype **must** implement the following functions:
 * `add_ph_objective_terms(sp::<ConcreteSubtype>, vids::Vector{VariableID}, r::Union{Float64, Dict{VariableID,Float64}})::Nothing
 * `objective_value(sp::<ConcreteSubtype>)::Float64`
 * `report_values(sp::<ConcreteSubtype>, vars::Vector{VariableID})::Dict{VariableID,Float64}`
@@ -40,9 +40,14 @@ To use the extensive form functionality, the concrete subtype must implement
 * `ef_node_dict_constructor(::Type{S}) where S <: AbstractSubproblem`
 See the help on the functions for more details. See JuMPSubproblem for an example using JuMP. Note that the extensive form model is always constructed as a `JuMP.Model` object.
 
-To use penalty parameter types other than `ScalarPenaltyParameter`, concrete subproblem types may also need to implement
-* `report_penalty_info(as::AbstractSubproblem, pp<:AbstractPenaltyParameter)::Dict{VariableID,Float64}`
+To use penalty parameter types other than `ScalarPenaltyParameter`, concrete subproblem types also need to implement
+* `report_penalty_info(sp::<ConcreateSubtype>, pp<:AbstractPenaltyParameter)::Dict{VariableID,Float64}`
 See the help on individual penalty parameter types and `report_penalty_info` for more details.
+
+To use lower bound computation functionality, the concrete subtype must also implement
+* `add_lagrange_terms(as::AbstractSubproblem, vids::Vector{VariableID})::Nothing
+* `update_lagrange_terms(as::AbstractSubproblem, vids::Dict{VariableID,Float64})::Nothing
+See the help on these functions for more details.
 """
 abstract type AbstractSubproblem end
 
@@ -57,7 +62,7 @@ abstract type AbstractSubproblem end
                            r::Union{Float64,Dict{VariableID,Float64}}
                            )::Dict{VariableID,Float64}
 
-Create model variables for Lagrange multipliers and hat variables and add lagrange and quadratic penalty terms to the objective function.
+Create model variables for Lagrange multipliers and hat variables and add Lagrange and proximal terms to the objective function.
 
 Returns mapping of the variable to any information needed from the subproblem to compute the penalty parameter. Only used if `is_subproblem_dependent(typeof(r))` returns `true`.
 
@@ -167,6 +172,8 @@ Update the values of the PH variables in this subproblem with those given by `w_
 **Arguments**
 
 * `as::AbstractSubproblem` : subproblem object (replace with appropriate type)
+* `w_vals::Dict{VariableID,Float64}` : Values to update Lagrangian variables with
+* `xhat_vals::Dict{VariableID,Float64}` : Values to update proximal variables with
 """
 function update_ph_terms(as::AbstractSubproblem,
                          w_vals::Dict{VariableID,Float64},
@@ -191,7 +198,18 @@ end
 ## Optional Interface Functions ##
 
 """
-TODO: Add documentation!!
+    add_lagrange_terms(as::AbstractSubproblem,
+                       vids::Vector{VariableID}
+                       )::Nothing
+
+Create model variables for Lagrange multipliers and adds the corresponding terms to the objective function.
+
+**Arguments**
+
+* `as::AbstractSubproblem` : subproblem object (replace with appropriate type)
+* `vids::Vector{VariableID}` : list of `VariableIDs` which need Lagrange terms
+
+See also [`add_ph_objective_terms`](@ref).
 """
 function add_lagrange_terms(as::AbstractSubproblem,
                             vids::Vector{VariableID}
@@ -200,10 +218,21 @@ function add_lagrange_terms(as::AbstractSubproblem,
 end
 
 """
-TODO: Add documentation!!
+    update_lagrange_terms(as::AbstractSubproblem,
+                          w_vals::Dict{VariableID,Float64}
+                          )::Nothing
+
+Update the values of the dual variables in this subproblem with those given by `w_vals`.
+
+**Arguments**
+
+* `as::AbstractSubproblem` : subproblem object (replace with appropriate type)
+* `w_vals::Dict{VariableID,Float64}` : values to update Lagrange dual variables with
+
+See also [`update_ph_terms`](@ref).
 """
 function update_lagrange_terms(as::AbstractSubproblem,
-                               vids::Dict{VariableID,Float64}
+                               w_vals::Dict{VariableID,Float64}
                                )::Nothing
     throw(UnimplementedError("update_lagrange_terms is unimplemented"))
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -45,9 +45,8 @@ function visualize_tree(phd::PHData)
 end
 
 ## Complex PHData Interaction Functions ##
-# NOTE: These functions are almost always post-processing functions
 
-# TODO: Add documentation to these functions
+# NOTE: These functions are almost all post-processing functions
 
 """
     lower_bounds(phd::PHData)::DataFrames.DataFrame
@@ -160,7 +159,7 @@ function retrieve_aug_obj_value(phd::PHData)::Float64
 end
 
 """
-    retrieve_aug_obj_value(phd::PHData)::Float64
+    retrieve_obj_value(phd::PHData)::Float64
 
 Return the current objective value without Lagrange and proximal PH terms.
 """

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -199,7 +199,7 @@ end
 function retrieve_xhat_history(phd::PHData)::DataFrames.DataFrame
 
     xhat_df = nothing
-    iterates = phd.iterate_history.iterates
+    iterates = phd.history.iterates
 
     for iter in sort!(collect(keys(iterates)))
 
@@ -229,7 +229,7 @@ end
 function retrieve_no_hat_history(phd::PHData)::DataFrames.DataFrame
 
     x_df = nothing
-    iterates = phd.iterate_history.iterates
+    iterates = phd.history.iterates
 
     for iter in sort!(collect(keys(iterates)))
 
@@ -258,7 +258,7 @@ end
 function retrieve_w_history(phd::PHData)::DataFrames.DataFrame
 
     w_df = nothing
-    iterates = phd.iterate_history.iterates
+    iterates = phd.history.iterates
 
     for iter in sort!(collect(keys(iterates)))
 
@@ -282,4 +282,59 @@ function retrieve_w_history(phd::PHData)::DataFrames.DataFrame
     end
 
     return w_df
+end
+
+function residuals(phd::PHData)::DataFrames.DataFrame
+
+    res_df = nothing
+    residuals = phd.history.residuals
+
+    for iter in sort!(collect(keys(residuals)))
+        res = residuals[iter]
+        data = Dict{String,Any}("iteration" => iter,
+                                "absolute" => res.abs_res,
+                                "relative" => res.rel_res,
+                                "xhat_sq" => res.xhat_sq,
+                                "x_sq" => res.x_sq
+                                )
+
+        if res_df == nothing
+            res_df = DataFrames.DataFrame(data)
+        else
+            push!(res_df, data)
+        end
+    end
+
+    if res_df == nothing
+        res_df = DataFrames.DataFrame()
+    end
+
+    return res_df
+end
+
+function lower_bounds(phd::PHData)::DataFrames.DataFrame
+
+    lb_df = nothing
+    lower_bounds = phd.history.lower_bounds
+
+    for iter in sort!(collect(keys(lower_bounds)))
+        lb = lower_bounds[iter]
+        data = Dict{String,Any}("iteration" => iter,
+                                "bound" => lb.lower_bound,
+                                "absolute gap" => lb.gap,
+                                "relative gap" => lb.rel_gap,
+                                )
+
+        if lb_df == nothing
+            lb_df = DataFrames.DataFrame(data)
+        else
+            push!(lb_df, data)
+        end
+    end
+
+    if lb_df == nothing
+        lb_df = DataFrames.DataFrame()
+    end
+
+    return lb_df
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,54 +1,5 @@
-function name(phd::PHData, vid::VariableID)::String
-    if !haskey(phd.variable_data, vid)
-        error("No name available for variable id $vid")
-    end
-    return phd.variable_data[vid].name
-end
 
-function value(phd::PHData, vid::VariableID)::Float64
-    return retrieve_variable_value(phd.scenario_map[scenario(vid)], vid)
-end
-
-function value(phd::PHData, scen::ScenarioID, stage::StageID, idx::Index)::Float64
-    vid = VariableID(scen, stage, idx)
-    return value(phd, vid)
-end
-
-function branch_value(phd::PHData, vid::VariableID)::Float64
-    return phd.scenario_map[scenario(vid)].branch_vars[vid]
-end
-
-function branch_value(phd::PHData, scen::ScenarioID, stage::StageID, idx::Index)::Float64
-    return branch_value(phd, VariableID(scen, stage, idx))
-end
-
-function leaf_value(phd::PHData, vid::VariableID)::Float64
-    return phd.scenario_map[scenario(vid)].leaf_vars[vid]
-end
-
-function leaf_value(phd::PHData, scen::ScenarioID, stage::StageID, idx::Index)::Float64
-    return leaf_value(phd, VariableID(scen, stage, idx))
-end
-
-function w_value(phd::PHData, vid::VariableID)::Float64
-    return phd.scenario_map[scenario(vid)].w_vars[vid]
-end
-
-function w_value(phd::PHData, scen::ScenarioID, stage::StageID, idx::Index)::Float64
-    return w_value(phd, VariableID(scen, stage, idx))
-end
-
-function xhat_value(phd::PHData, xhat_id::XhatID)::Float64
-    return value(phd.xhat[xhat_id])
-end
-
-function xhat_value(phd::PHData, vid::VariableID)::Float64
-    return xhat_value(phd, convert_to_xhat_id(phd, vid))
-end
-
-function xhat_value(phd::PHData, scen::ScenarioID, stage::StageID, idx::Index)::Float64
-    return xhat_value(phd, VariableID(scen, stage, idx))
-end
+## Helper Functions ##
 
 function stringify(set::Set{K})::String where K
     str = ""
@@ -65,6 +16,31 @@ function stringify(array::Vector{K})::String where K
     end
     return rstrip(str, [',',' '])
 end
+
+## Generic Utility Functions ##
+
+function two_stage_tree(n::Int;
+                        pvect::Union{Nothing,Vector{R}}=nothing
+                        )::ScenarioTree where R <: Real
+    p = pvect == nothing ? [1.0/n for k in 1:n] : pvect
+
+    st = ScenarioTree()
+    for k in 1:n
+        add_leaf(st, root(st), p[k])
+    end
+    return st
+end
+
+function visualize_tree(phd::PHData)
+    # TODO: Implement this...
+    @warn("Not yet implemented")
+    return
+end
+
+## Complex PHData Interaction Functions ##
+# NOTE: These functions are almost always post-processing functions
+
+# TODO: Add documentation to these functions
 
 function retrieve_soln(phd::PHData)::DataFrames.DataFrame
 
@@ -122,24 +98,6 @@ function retrieve_obj_value(phd::PHData)::Float64
     end
 
     return obj_value
-end
-
-function two_stage_tree(n::Int;
-                        pvect::Union{Nothing,Vector{R}}=nothing
-                        )::ScenarioTree where R <: Real
-    p = pvect == nothing ? [1.0/n for k in 1:n] : pvect
-
-    st = ScenarioTree()
-    for k in 1:n
-        add_leaf(st, root(st), p[k])
-    end
-    return st
-end
-
-function visualize_tree(phd::PHData)
-    # TODO: Implement this...
-    @warn("Not yet implemented")
-    return
 end
 
 function retrieve_no_hats(phd::PHData)::DataFrames.DataFrame

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -22,7 +22,7 @@ end
 function two_stage_tree(n::Int;
                         pvect::Union{Nothing,Vector{R}}=nothing
                         )::ScenarioTree where R <: Real
-    p = pvect == nothing ? [1.0/n for k in 1:n] : pvect
+    p = isnothing(pvect) ? [1.0/n for k in 1:n] : pvect
 
     st = ScenarioTree()
     for k in 1:n
@@ -170,14 +170,14 @@ function retrieve_xhat_history(phd::PHData)::DataFrames.DataFrame
             end
         end
 
-        if xhat_df == nothing
+        if isnothing(xhat_df)
             xhat_df = DataFrames.DataFrame(data)
         else
             push!(xhat_df, data)
         end
     end
 
-    if xhat_df == nothing
+    if isnothing(xhat_df)
         xhat_df = DataFrames.DataFrame()
     end
 
@@ -199,14 +199,14 @@ function retrieve_no_hat_history(phd::PHData)::DataFrames.DataFrame
             data[vname] = current_iterate.x[vid]
         end
 
-        if x_df == nothing
+        if isnothing(x_df)
             x_df = DataFrames.DataFrame(data)
         else
             push!(x_df, data)
         end
     end
 
-    if x_df == nothing
+    if isnothing(x_df)
         x_df = DataFrames.DataFrame()
     end
 
@@ -228,14 +228,14 @@ function retrieve_w_history(phd::PHData)::DataFrames.DataFrame
             data[vname] = current_iterate.w[vid]
         end
 
-        if w_df == nothing
+        if isnothing(w_df)
             w_df = DataFrames.DataFrame(data)
         else
             push!(w_df, data)
         end
     end
 
-    if w_df == nothing
+    if isnothing(w_df)
         w_df = DataFrames.DataFrame()
     end
 
@@ -256,14 +256,14 @@ function residuals(phd::PHData)::DataFrames.DataFrame
                                 "x_sq" => res.x_sq
                                 )
 
-        if res_df == nothing
+        if isnothing(res_df)
             res_df = DataFrames.DataFrame(data)
         else
             push!(res_df, data)
         end
     end
 
-    if res_df == nothing
+    if isnothing(res_df)
         res_df = DataFrames.DataFrame()
     end
 
@@ -283,14 +283,14 @@ function lower_bounds(phd::PHData)::DataFrames.DataFrame
                                 "relative gap" => lb.rel_gap,
                                 )
 
-        if lb_df == nothing
+        if isnothing(lb_df)
             lb_df = DataFrames.DataFrame(data)
         else
             push!(lb_df, data)
         end
     end
 
-    if lb_df == nothing
+    if isnothing(lb_df)
         lb_df = DataFrames.DataFrame()
     end
 

--- a/src/worker_management.jl
+++ b/src/worker_management.jl
@@ -31,6 +31,8 @@ function _check_wait(wi::WorkerInf,
                      msg_type::Type{M}
                      )::Union{Nothing,M} where M <: Message
 
+    # println("Checking wait queue...")
+
     retval = nothing
 
     for (k,msg) in enumerate(wi.wait)
@@ -73,14 +75,18 @@ function _launch_workers(min_worker_size::Int,
 end
 
 function _monitor_workers(wi::WorkerInf)::Nothing
+
     # println("Checking worker status...")
+
     for (pid, f) in pairs(wi.results)
         if isready(f)
             # Whatever the return value, this worker is done and
             # we can stop checking on it
             delete!(wi.results, pid)
             delete!(wi.inputs, pid)
+
             try
+
                 # Fetch on a remote process result will throw and error here
                 # whereas fetch on a task requires that it is thrown. Hence
                 # the try-catch AND the type check for an exception.
@@ -92,15 +98,22 @@ function _monitor_workers(wi::WorkerInf)::Nothing
                 else
                     error("Unexpected return code from worker: $e")
                 end
+
             catch e
+
                 _abort(wi)
                 rethrow()
+
             finally
+
                 ;
+
             end
         end
     end
+
     return
+
 end
 
 function _number_workers(wi::WorkerInf)
@@ -108,6 +121,8 @@ function _number_workers(wi::WorkerInf)
 end
 
 function _retrieve_message(wi::WorkerInf)::Message
+
+    # println("Checking message queue...")
 
     while !isready(wi.output) && _is_running(wi)
         _monitor_workers(wi)
@@ -147,6 +162,7 @@ function _send_message(wi::WorkerInf,
                        wid::Int,
                        msg::Message,
                        )
+    # println("Sending message of type $(typeof(msg)) to worker $(wid)")
     put!(wi.inputs[wid], msg)
     return
 end

--- a/test/common.jl
+++ b/test/common.jl
@@ -120,7 +120,7 @@ function invert_map(my_map::Dict{A,B})::Dict{B,A} where {A,B}
     return inv_map
 end
 
-function two_stage_model(scenario_id::PH.ScenarioID)
+@everywhere function two_stage_model(scenario_id::PH.ScenarioID)
 
     model = JuMP.Model(()->Ipopt.Optimizer())
     JuMP.set_optimizer_attribute(model, "print_level", 0)
@@ -129,7 +129,7 @@ function two_stage_model(scenario_id::PH.ScenarioID)
 
     scen = PH.value(scenario_id)
 
-    ref = JuMP.@variable(model, x >= 0.0)
+    ref = JuMP.@variable(model, 0.0 <= x <= 1000.0)
     stage1 = [ref]
     push!(stage1, JuMP.@variable(model, 0.0 <= u <= 1.0))
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,8 +21,6 @@ macro optional_using(pkg)
         catch e
             if typeof(e) != ArgumentError
                 rethrow(e)
-            # else
-            #     println("Failed to find package $pkg")
             end
         end
     end
@@ -32,33 +30,35 @@ end
 
 include("common.jl")
 
-@testset "Scenario Tree" begin
-    include("test_tree.jl")
-end
-@testset "Sanity Checks" begin
-    include("test_sanity.jl")
-end
-@testset "Utils" begin
-    include("test_utils.jl")
-end
-@testset "Subproblem" begin
-    include("test_subproblem.jl")
-end
-@testset "Workers" begin
-    include("test_worker.jl")
-end
-@testset "Penalty Parameters" begin
-    include("test_penalty.jl")
-end
-@testset "Callbacks" begin
-    include("test_callback.jl")
-end
-@testset "Setup" begin
-    include("test_setup.jl")
-end
-@testset "Algorithm" begin
-    include("test_algorithm.jl")
-end
-@testset "Distributed" begin
-    include("test_distributed.jl")
+@testset "ProgressiveHedging" begin
+    @testset "Scenario Tree" begin
+        include("test_tree.jl")
+    end
+    @testset "Sanity Checks" begin
+        include("test_sanity.jl")
+    end
+    @testset "Utils" begin
+        include("test_utils.jl")
+    end
+    @testset "Subproblem" begin
+        include("test_subproblem.jl")
+    end
+    @testset "Workers" begin
+        include("test_worker.jl")
+    end
+    @testset "Penalty Parameters" begin
+        include("test_penalty.jl")
+    end
+    @testset "Callbacks" begin
+        include("test_callback.jl")
+    end
+    @testset "Setup" begin
+        include("test_setup.jl")
+    end
+    @testset "Algorithm" begin
+        include("test_algorithm.jl")
+    end
+    @testset "Distributed" begin
+        include("test_distributed.jl")
+    end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -41,8 +41,8 @@ end
 @testset "Utils" begin
     include("test_utils.jl")
 end
-@testset "JuMP Subproblem" begin
-    include("test_jumpsp.jl")
+@testset "Subproblem" begin
+    include("test_subproblem.jl")
 end
 @testset "Workers" begin
     include("test_worker.jl")

--- a/test/test_algorithm.jl
+++ b/test/test_algorithm.jl
@@ -210,6 +210,7 @@ end
 end
 
 @testset "Lower Bound Algorithm" begin
+
     (n, err, rerr, obj, soln, phd) = PH.solve(PH.two_stage_tree(2),
                                               two_stage_model,
                                               PH.ScalarPenaltyParameter(2.0),
@@ -234,4 +235,31 @@ end
     @test size(lb_df,1) == 12
     @test isapprox(lb_df[size(lb_df,1), "absolute gap"], 0.0, atol=1e-7)
     @test isapprox(lb_df[size(lb_df,1), "relative gap"], 0.0, atol=(1e-7/8.25))
+
+end
+
+@testset "Lower Bound Termination" begin
+
+    gap_tol = 1e-3
+
+    (n, err, rerr, obj, soln, phd) = PH.solve(PH.two_stage_tree(2),
+                                              two_stage_model,
+                                              PH.ScalarPenaltyParameter(2.0),
+                                              gap_tol=gap_tol,
+                                              atol=atol,
+                                              rtol=rtol,
+                                              max_iter=max_iter,
+                                              report=0,
+                                              lower_bound=5,
+                                              timing=false,
+                                              warm_start=false
+                                              )
+
+    lb_df = PH.lower_bounds(phd)
+
+    @test err > atol
+    @test rerr > rtol
+    @test n < max_iter
+    @test lb_df[size(lb_df,1), "relative gap"] < gap_tol
+
 end

--- a/test/test_algorithm.jl
+++ b/test/test_algorithm.jl
@@ -208,3 +208,30 @@ end
     #@test err < rtol * xmax
     @test rerr < rtol
 end
+
+@testset "Lower Bound Algorithm" begin
+    (n, err, rerr, obj, soln, phd) = PH.solve(PH.two_stage_tree(2),
+                                              two_stage_model,
+                                              PH.ScalarPenaltyParameter(2.0),
+                                              atol=atol,
+                                              rtol=rtol,
+                                              max_iter=max_iter,
+                                              report=0,
+                                              lower_bound=5,
+                                              timing=false,
+                                              warm_start=false
+                                              )
+
+    @test err < atol
+    @test isapprox(obj, 8.25, atol=1e-6)
+    @test n < max_iter
+
+    lb_df = PH.lower_bounds(phd)
+    for row in eachrow(lb_df)
+        @test row[:bound] <= 8.25
+    end
+
+    @test size(lb_df,1) == 12
+    @test isapprox(lb_df[size(lb_df,1), "absolute gap"], 0.0, atol=1e-7)
+    @test isapprox(lb_df[size(lb_df,1), "relative gap"], 0.0, atol=(1e-7/8.25))
+end

--- a/test/test_callback.jl
+++ b/test/test_callback.jl
@@ -224,18 +224,25 @@ end
 end
 
 @testset "Subproblem Callback" begin
-        spcb_text = "SubproblemCallback succesful."
-    function my_subproblem_callback(
-            ext::Dict{Symbol,Any}, sp::JuMPSubproblem, niter::Int, 
-            scenario_id::ScenarioID
-        )
+
+    # TODO: Improve this test
+
+    function my_subproblem_callback(ext::Dict{Symbol,Any},
+                                    sp::JuMPSubproblem,
+                                    niter::Int,
+                                    scenario_id::ScenarioID
+                                    )
+
         if niter == 1 && scenario_id.value == 0
             ext[:check] += 1
             sp.model.ext[:check] = 1
         end
+
         if niter == 2 && scenario_id.value == 0
             ext[:sp_check] = sp.model.ext[:check]
         end
+
+        return
     end
 
     ext = Dict{Symbol,Any}(:check => 0)
@@ -244,11 +251,11 @@ end
                                             create_model,
                                             PH.ScalarPenaltyParameter(25.0),
                                             opt=Ipopt.Optimizer,
-                                            opt_args=(print_level=1,tol=1e-12),
-                                            atol=1e-6,
+                                            opt_args=(print_level=0,tol=1e-12),
+                                            atol=5e-1,
                                             rtol=1e-8,
-                                            max_iter=2,
-                                            report=1,
+                                            max_iter=10,
+                                            report=0,
                                             timing=false,
                                             warm_start=false,
                                             subproblem_callbacks=[my_spcb]


### PR DESCRIPTION
Add the ability to perform lower bound computations during the PH run as described by [(Gade, et. al., 2016)](https://link.springer.com/article/10.1007/s10107-016-1000-z).

- [x] Implement in subproblem
- [x] Add computation to algorithm
- [x] Add lower-bound computation option to solve function
- [x] Add tests for computations, options, etc.
- [x] Add ability to save lower bounds
- [x] Tests for saving lower bounds
- [x] Add gap termination condition
- [x] Test for gap termination condition
- [ ] Asynchronous lower bound execution
- [ ] Tests for asynchronous execution

