### PR TITLE
Change order of call to warm start and reset penalty parameter before solving

### DIFF
--- a/src/ProgressiveHedging.jl
+++ b/src/ProgressiveHedging.jl
@@ -179,6 +179,8 @@ function solve(tree::ScenarioTree,
                ) where {R <: AbstractPenaltyParameter}
                
     timo = TimerOutputs.TimerOutput()
+    
+    reset_penalty_parameter(r)
 
     if length(scenarios(tree)) == 1
         @warn("Given scenario tree indicates a deterministic problem (only one scenario).")

--- a/src/ProgressiveHedging.jl
+++ b/src/ProgressiveHedging.jl
@@ -180,7 +180,7 @@ function solve(tree::ScenarioTree,
                
     timo = TimerOutputs.TimerOutput()
     
-    reset_penalty_parameter(r)
+    r = reset_penalty_parameter(r)
 
     if length(scenarios(tree)) == 1
         @warn("Given scenario tree indicates a deterministic problem (only one scenario).")

--- a/src/ProgressiveHedging.jl
+++ b/src/ProgressiveHedging.jl
@@ -151,9 +151,9 @@ Solve the stochastic programming problem described by `tree` and the models crea
 **Return Arguments**
 
 * `niter` : Number of iterations performed.
-* `abs_res` : Absolute residual (of what?).
-* `rel_res` : Relative residual (of what?).
-* `obj` : Objective value (not including augmented terms?).
+* `abs_res` : Absolute residual. The sum of the L2 norm of movement between consensus variables from one iteration to the next and the L2 norm of the lack of consensus divided by the number of consensus variables.
+* `rel_res` : Relative residual. The absolute residual divided by the maximum consensus variable value.
+* `obj` : Objective value with progressive hedging terms removed.
 * `soln_df` : `DataFrame` containing variables, their values and their stage and scenario IDs.
 * `phd` : A data structure used for the progressive hedging algorithm. See `PHData` for more information.
 """

--- a/src/ProgressiveHedging.jl
+++ b/src/ProgressiveHedging.jl
@@ -180,7 +180,7 @@ function solve(tree::ScenarioTree,
                
     timo = TimerOutputs.TimerOutput()
     
-    r = reset_penalty_parameter(r)
+    reset_penalty_parameter(r)
 
     if length(scenarios(tree)) == 1
         @warn("Given scenario tree indicates a deterministic problem (only one scenario).")

--- a/src/ProgressiveHedging.jl
+++ b/src/ProgressiveHedging.jl
@@ -180,7 +180,7 @@ function solve(tree::ScenarioTree,
                
     timo = TimerOutputs.TimerOutput()
     
-    reset_penalty_parameter(r)
+    reset_penalty_map(r)
 
     if length(scenarios(tree)) == 1
         @warn("Given scenario tree indicates a deterministic problem (only one scenario).")

--- a/src/ProgressiveHedging.jl
+++ b/src/ProgressiveHedging.jl
@@ -147,6 +147,15 @@ Solve the stochastic programming problem described by `tree` and the models crea
 * `worker_assignments::Dict{Int,Set{ScenarioID}}` : Dictionary specifying which scenario subproblems a worker will create and solve. The key values are worker ids as given by Distributed (see `Distributed.workers()`). The user is responsible for ensuring the specified workers exist and that every scenario is assigned to a worker. If no dictionary is given, scenarios are assigned to workers in round robin fashion. Defaults to empty dictionary.
 * `args::Tuple` : Tuple of arguments to pass to `model_cosntructor`. Defaults to (). See also `other_args` and `kwargs`.
 * `kwargs` : Any keyword arguments not specified here that need to be passed to `subproblem_constructor`.  See also `other_args` and `args`.
+
+**Return Arguments**
+
+* `niter` : Number of iterations performed.
+* `abs_res` : Absolute residual (of what?).
+* `rel_res` : Relative residual (of what?).
+* `obj` : Objective value (not including augmented terms?).
+* `soln_df` : `DataFrame` containing variables, their values and their stage and scenario IDs.
+* `phd` : A data structure used for the progressive hedging algorithm. See `PHData` for more information.
 """
 function solve(tree::ScenarioTree,
                subproblem_constructor::Function,

--- a/src/penalty_parameter_functions.jl
+++ b/src/penalty_parameter_functions.jl
@@ -86,8 +86,8 @@ end
 """
 Resets any mapping of consensus variable ids to penalty parameter values which `r` may have. This avoids potential bugs caused by the same instance of a penalty parameter being used for several calls to `solve`.
 """
-function reset_penalty_parameter(r::AbstractPenaltyParameter)::Nothing
-    throw(UnimplementedError("reset_penalty_parameter is unimplemented for penalty parameter of type $(typeof(r))."))
+function reset_penalty_map(r::AbstractPenaltyParameter)::Nothing
+    return 
 end
 
 #### Concrete Implementations ####
@@ -144,11 +144,11 @@ function is_variable_dependent(::Type{ProportionalPenaltyParameter})::Bool
     return true
 end
 
-function reset_penalty_parameter(r::ProportionalPenaltyParameter)::Nothing
+function reset_penalty_map(r::ProportionalPenaltyParameter)::Nothing
     for k in keys(r.penalties)
         delete!(r.penalties, k)
     end
-    return nothing
+    return
 end
 
 ## Scalar Penalty Parameter ##
@@ -173,10 +173,6 @@ end
 
 function is_variable_dependent(::Type{ScalarPenaltyParameter})::Bool
     return false
-end
-
-function reset_penalty_parameter(r::ScalarPenaltyParameter)::Nothing
-    return nothing
 end
 
 ## SEP Penalty Parameter ##
@@ -279,9 +275,9 @@ function is_variable_dependent(::Type{SEPPenaltyParameter})::Bool
     return true
 end
 
-function reset_penalty_parameter(r::SEPPenaltyParameter)::Nothing
+function reset_penalty_map(r::SEPPenaltyParameter)::Nothing
     for k in keys(r.penalties)
         delete!(r.penalties, k)
     end
-    return nothing
+    return
 end

--- a/src/penalty_parameter_functions.jl
+++ b/src/penalty_parameter_functions.jl
@@ -107,6 +107,8 @@ function process_penalty_subproblem(r::ProportionalPenaltyParameter,
                                     penalties::Dict{VariableID,Float64}
                                     )::Nothing
 
+    @error r.penalties
+    @error "HELLO"
     for (vid, penalty) in pairs(penalties)
 
         xhid = convert_to_xhat_id(phd, vid)
@@ -114,7 +116,10 @@ function process_penalty_subproblem(r::ProportionalPenaltyParameter,
 
         if haskey(r.penalties, xhid)
             if !isapprox(r.penalties[xhid], r_value)
-                error("Penalty parameter must match across scenarios. Got $(r.penalties[xhid]) instead of $(penalty) for variable $(name(phd, xhid)). This error likely means the coefficients in the objective function do not match in the scenario subproblems.")
+                error("Penalty parameter must match across scenarios. Got $(r.penalties[xhid]) instead of $(penalty) for variable $(name(phd, xhid)) when processing penalty parameter for scenario $(scid). This error could mean that:
+                    1. The coefficients in the objective function do not match in the scenario subproblems
+                    2. The variable specific penalties were set in the penalty parameter before the call to `PH.solve`."
+                    )
             end
         else
             r.penalties[xhid] = r_value
@@ -246,7 +251,10 @@ function process_penalty_subproblem(r::SEPPenaltyParameter,
 
         if haskey(r.penalties, xhid)
             if !isapprox(r.penalties[xhid], penalty)
-                error("Penalty parameter must match across scenarios. Got $(r.penalties[xhid]) instead of $(penalty) for variable $(name(phd, xhid)). This error likely means the coefficients in the objective function do not match in the scenario subproblems.")
+                error("Penalty parameter must match across scenarios. Got $(r.penalties[xhid]) instead of $(penalty) for variable $(name(phd, xhid)) when processing penalty parameter for scenario $(scid). This error could mean that:
+                    1. The coefficients in the objective function do not match in the scenario subproblems
+                    2. The variable specific penalties were set in the penalty parameter before the call to `PH.solve`."
+                    )
             end
         else
             r.penalties[xhid] = penalty

--- a/src/penalty_parameter_functions.jl
+++ b/src/penalty_parameter_functions.jl
@@ -114,10 +114,7 @@ function process_penalty_subproblem(r::ProportionalPenaltyParameter,
 
         if haskey(r.penalties, xhid)
             if !isapprox(r.penalties[xhid], r_value)
-                error("Penalty parameter must match across scenarios. Got $(r.penalties[xhid]) instead of $(penalty) for variable $(name(phd, xhid)) when processing penalty parameter for scenario $(scid). This error could mean that:
-                    1. The coefficients in the objective function do not match in the scenario subproblems
-                    2. The variable specific penalties were set in the penalty parameter before the call to `PH.solve`."
-                    )
+                error("Penalty parameter must match across scenarios. Got $(r.penalties[xhid]) instead of $(penalty) for variable $(name(phd, xhid)) when processing penalty parameter for scenario $(scid). This error likely means the coefficients in the objective function do not match in the scenario subproblems.")
             end
         else
             r.penalties[xhid] = r_value
@@ -138,6 +135,10 @@ end
 
 function is_variable_dependent(::Type{ProportionalPenaltyParameter})::Bool
     return true
+end
+
+function reset_penalty_parameter(r::ProportionalPenaltyParameter)::ProportionalPenaltyParameter
+    return ProportionalPenaltyParameter(r.constant, Dict{XhatID,Float64}())
 end
 
 ## Scalar Penalty Parameter ##
@@ -162,6 +163,10 @@ end
 
 function is_variable_dependent(::Type{ScalarPenaltyParameter})::Bool
     return false
+end
+
+function reset_penalty_parameter(r::ScalarPenaltyParameter)::ScalarPenaltyParameter
+    return r
 end
 
 ## SEP Penalty Parameter ##
@@ -249,10 +254,7 @@ function process_penalty_subproblem(r::SEPPenaltyParameter,
 
         if haskey(r.penalties, xhid)
             if !isapprox(r.penalties[xhid], penalty)
-                error("Penalty parameter must match across scenarios. Got $(r.penalties[xhid]) instead of $(penalty) for variable $(name(phd, xhid)) when processing penalty parameter for scenario $(scid). This error could mean that:
-                    1. The coefficients in the objective function do not match in the scenario subproblems
-                    2. The variable specific penalties were set in the penalty parameter before the call to `PH.solve`."
-                    )
+                error("Penalty parameter must match across scenarios. Got $(r.penalties[xhid]) instead of $(penalty) for variable $(name(phd, xhid)) when processing penalty parameter for scenario $(scid). This error likely means the coefficients in the objective function do not match in the scenario subproblems.")
             end
         else
             r.penalties[xhid] = penalty
@@ -265,4 +267,8 @@ end
 
 function is_variable_dependent(::Type{SEPPenaltyParameter})::Bool
     return true
+end
+
+function reset_penalty_parameter(r::SEPPenaltyParameter)::SEPPenaltyParameter
+    return SEPPenaltyParameter(r.default, Dict{XhatID,Float64}())
 end

--- a/src/penalty_parameter_functions.jl
+++ b/src/penalty_parameter_functions.jl
@@ -107,8 +107,6 @@ function process_penalty_subproblem(r::ProportionalPenaltyParameter,
                                     penalties::Dict{VariableID,Float64}
                                     )::Nothing
 
-    @error r.penalties
-    @error "HELLO"
     for (vid, penalty) in pairs(penalties)
 
         xhid = convert_to_xhat_id(phd, vid)

--- a/src/penalty_parameter_functions.jl
+++ b/src/penalty_parameter_functions.jl
@@ -83,6 +83,13 @@ function process_penalty_subproblem(r::AbstractPenaltyParameter,
     throw(UnimplementedError("process_penalty_subproblem is unimplemented for penalty parameter of type $(typeof(r))."))
 end
 
+"""
+Resets any mapping of consensus variable ids to penalty parameter values which `r` may have. This avoids potential bugs caused by the same instance of a penalty parameter being used for several calls to `solve`.
+"""
+function reset_penalty_parameter(r::AbstractPenaltyParameter)::Nothing
+    throw(UnimplementedError("reset_penalty_parameter is unimplemented for penalty parameter of type $(typeof(r))."))
+end
+
 #### Concrete Implementations ####
 
 ## Proportional Penalty Parameter ##
@@ -137,8 +144,11 @@ function is_variable_dependent(::Type{ProportionalPenaltyParameter})::Bool
     return true
 end
 
-function reset_penalty_parameter(r::ProportionalPenaltyParameter)::ProportionalPenaltyParameter
-    return ProportionalPenaltyParameter(r.constant, Dict{XhatID,Float64}())
+function reset_penalty_parameter(r::ProportionalPenaltyParameter)::Nothing
+    for k in keys(r.penalties)
+        delete!(r.penalties, k)
+    end
+    return nothing
 end
 
 ## Scalar Penalty Parameter ##
@@ -165,8 +175,8 @@ function is_variable_dependent(::Type{ScalarPenaltyParameter})::Bool
     return false
 end
 
-function reset_penalty_parameter(r::ScalarPenaltyParameter)::ScalarPenaltyParameter
-    return r
+function reset_penalty_parameter(r::ScalarPenaltyParameter)::Nothing
+    return nothing
 end
 
 ## SEP Penalty Parameter ##
@@ -269,6 +279,9 @@ function is_variable_dependent(::Type{SEPPenaltyParameter})::Bool
     return true
 end
 
-function reset_penalty_parameter(r::SEPPenaltyParameter)::SEPPenaltyParameter
-    return SEPPenaltyParameter(r.default, Dict{XhatID,Float64}())
+function reset_penalty_parameter(r::SEPPenaltyParameter)::Nothing
+    for k in keys(r.penalties)
+        delete!(r.penalties, k)
+    end
+    return nothing
 end

--- a/src/penalty_parameter_types.jl
+++ b/src/penalty_parameter_types.jl
@@ -11,6 +11,7 @@ All concrete subtypes must implement the following methods:
 * `is_initial_value_dependent(::Type{<ConcreteSubtype>})::Bool`
 * `is_subproblem_dependent(::Type{<ConcreteSubtype>})::Bool`
 * `is_variable_dependent(::Type{<ConcreateSubtype>})::Bool`
+* `reset_penalty_parameter(r::<ConcreteSubtype>)::Nothing`
 
 If `is_initial_value_dependent` returns `true`, then the concrete subtype must implement
 * `process_penalty_initial_value(r::<ConcreteSubtype>, ph_data::PHData)::Nothing`

--- a/src/penalty_parameter_types.jl
+++ b/src/penalty_parameter_types.jl
@@ -11,7 +11,6 @@ All concrete subtypes must implement the following methods:
 * `is_initial_value_dependent(::Type{<ConcreteSubtype>})::Bool`
 * `is_subproblem_dependent(::Type{<ConcreteSubtype>})::Bool`
 * `is_variable_dependent(::Type{<ConcreateSubtype>})::Bool`
-* `reset_penalty_parameter(r::<ConcreteSubtype>)::Nothing`
 
 If `is_initial_value_dependent` returns `true`, then the concrete subtype must implement
 * `process_penalty_initial_value(r::<ConcreteSubtype>, ph_data::PHData)::Nothing`
@@ -23,6 +22,7 @@ Additionally, the concrete subproblem type must implement the function
 
 If `is_variable_dependent` returns `true`, then the concrete subtype must implement
 * `penalty_map(r::<ConcreteSubtype>)::Dict{XhatID,Float64}`
+* `reset_penalty_map(r::<ConcreteSubtype>)::Nothing`
 If `is_variable_dependent` returns `false`, then the concrete subtype must implement
 * `get_penalty_value(r::<ConcreteSubtype>)::Float64`
 

--- a/src/worker.jl
+++ b/src/worker.jl
@@ -172,12 +172,9 @@ function process_message(msg::Solve,
 
     _execute_subproblem_callbacks(sub, msg.niter, msg.scen)
 
-    if record.warm_start
-        warm_start(sub.problem)
-    end
-
     start = time()
     sts = solve_subproblem(sub.problem)
+    record.warm_start && warm_start(sub.problem)
     stop = time()
     var_vals = report_values(sub.problem, sub.branch_vars)
 
@@ -204,12 +201,9 @@ function process_message(msg::SolveLowerBound,
     lb_sub = record.lb_subproblems[msg.scen]
     update_lagrange_terms(lb_sub.problem, msg.w_vals)
 
-    if record.warm_start
-        warm_start(lb_sub.problem)
-    end
-
     start = time()
     sts = solve_subproblem(lb_sub.problem)
+    record.warm_start && warm_start(lb_sub.problem)
     stop = time()
 
     put!(output, ReportLowerBound(msg.scen,
@@ -309,6 +303,7 @@ function _initial_solve(output::RemoteChannel,
 
         start = time()
         sts = solve_subproblem(sub.problem)
+        record.warm_start && warm_start(sub.problem)
         stop = time()
         var_vals = report_values(sub.problem, sub.branch_vars)
         put!(output, ReportBranch(scen,

--- a/src/worker.jl
+++ b/src/worker.jl
@@ -174,8 +174,12 @@ function process_message(msg::Solve,
 
     start = time()
     sts = solve_subproblem(sub.problem)
-    record.warm_start && warm_start(sub.problem)
     stop = time()
+    
+    if record.warm_start == true
+        warm_start(sub.problem)
+    end
+    
     var_vals = report_values(sub.problem, sub.branch_vars)
 
     put!(output, ReportBranch(msg.scen,
@@ -203,8 +207,11 @@ function process_message(msg::SolveLowerBound,
 
     start = time()
     sts = solve_subproblem(lb_sub.problem)
-    record.warm_start && warm_start(lb_sub.problem)
     stop = time()
+        
+    if record.warm_start == true
+        warm_start(sub.problem)
+    end
 
     put!(output, ReportLowerBound(msg.scen,
                                   sts,
@@ -303,8 +310,12 @@ function _initial_solve(output::RemoteChannel,
 
         start = time()
         sts = solve_subproblem(sub.problem)
-        record.warm_start && warm_start(sub.problem)
         stop = time()
+        
+        if record.warm_start == true
+            warm_start(sub.problem)
+        end
+        
         var_vals = report_values(sub.problem, sub.branch_vars)
         put!(output, ReportBranch(scen,
                                   sts,

--- a/test/test_penalty.jl
+++ b/test/test_penalty.jl
@@ -138,3 +138,13 @@ end
         println("Skipping SEP integer setting tests.")
     end
 end
+
+@testset "Reset penalty parameters" begin
+    for r in (PH.ProportionalPenaltyParameter(1.0), PH.SEPPenaltyParameter(1.0))
+        @test isempty(r.penalties) == true
+        r.penalties[PH.XhatID(PH.NodeID(0), PH.Index(0))] = 1.0
+        @test isempty(r.penalties) == false
+        PH.reset_penalty_parameter(r)
+        @test isempty(r.penalties) == true
+    end
+end


### PR DESCRIPTION
Fixes #36

Warm start is now called directly after solving a subproblem. I think this may seem a bit weird, but I don't see how it's incorrect (although the last warm start will admittedly be useless). Now warm start works with Gurobi, though I noticed there's no real checks to see if warm start "works", just a check to see if the correct solution is returned. 

Additionally I added a doc string for the return args of `solve`, since I always find myself having to look at the GitHub documentation to remember what's returned. 